### PR TITLE
Add consulted keys automatically to key cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 var consul = require('consul')(),
     cachedKeys = new Array(),
     cachedKeysUpdatedCount = 0,
-    refreshInterval = 1 * 60 * 1000, // 2 minutes
+    refreshInterval = 1 * 60 * 1000, // 1 minute
     intervalDescriptor;
 
 module.exports = {
@@ -32,7 +32,15 @@ module.exports = {
         if (cachedKeys.hasOwnProperty(key)) {
             return cachedKeys[key];
         }
-        return false;
+
+        cachedKeys[key] = null;
+        if (!intervalDescriptor) {
+          module.exports.refresh();
+          intervalDescriptor = setInterval( (function() {
+            module.exports.refresh();
+          }).bind(this), refreshInterval);
+        }
+        return cachedKeys[key];
     },
 
     refresh: function(callback) {


### PR DESCRIPTION
This enables consul-kv to be used without initalizing it beforehand,
which might come handy from time to time when strong consistency at
the first consultation is not required.